### PR TITLE
fix: conda not found

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -xe
 
 echo "TACC: job ${SLURM_JOB_ID} execution at: $(date)"
 echo load cuda
@@ -40,16 +41,16 @@ fi
 
 echo "Initializing conda..."
 $WORK/miniconda3/bin/conda init bash
-conda info 
+conda info
 echo "Sourcing .bashrc..."
 source ~/.bashrc
 
 if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
     echo "Env not found, downloading"
-    wget https://github.com/In-For-Disaster-Analytics/sites-and-stories-nlp/archive/refs/heads/jupyterenv.zip 
+    wget https://github.com/In-For-Disaster-Analytics/sites-and-stories-nlp/archive/refs/heads/jupyterenv.zip
     unzip *.zip -d $WORK
-    CONDA_PKGS_DIRS=$(mktemp -d) conda create -n llm -f $WORK/sites-and-stories-nlp-jupyterenv/.binder/environment.yml 
-fi 
+    CONDA_PKGS_DIRS=$(mktemp -d) conda create -n llm -f $WORK/sites-and-stories-nlp-jupyterenv/.binder/environment.yml
+fi
 echo "Installing Conda env"
 python -m ipykernel install --user --name llm --display-name "Python (llm)"
 conda activate llm
@@ -57,7 +58,7 @@ pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-h
 echo "\
 import torch
 print(torch.cuda.is_available())
-" | python3      
+" | python3
 
 export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
 
@@ -131,7 +132,7 @@ c.${JUPYTER_SERVER_APP}.root_dir = "$WORK/sites-and-stories-nlp-jupyterenv"
 c.${JUPYTER_SERVER_APP}.preferred_dir = "$WORK/sites-and-stories-nlp-jupyterenv"
 c.IdentityProvider.token = "${TAP_TOKEN}"
 c.NotebookApp.notebook_dir = '$WORK/sites-and-stories-nlp-jupyterenv'
-c.MultiKernelManager.default_kernel_name = 'llm' 
+c.MultiKernelManager.default_kernel_name = 'llm'
 EOF
 
 # launch jupyter

--- a/run.sh
+++ b/run.sh
@@ -41,9 +41,9 @@ fi
 
 echo "Initializing conda..."
 $WORK/miniconda3/bin/conda init bash
-conda info
 echo "Sourcing .bashrc..."
 source ~/.bashrc
+conda info
 
 if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
     echo "Env not found, downloading"


### PR DESCRIPTION
The error "conda not found" was real, but it is not critical. It was failing at the line: "conda info". I added two bash options to improve the debugging.

In Bash, the set command is used to change the behavior of the shell. The -e and -x options in your example have specific meanings:

-e option (errexit):

When this option is set, the shell will exit immediately if any command it runs exits with a non-zero status (i.e., if it encounters an error).
This is often used to make shell scripts more robust, ensuring that if any command fails, the script stops executing to prevent further issues.
bash
Copy code
set -e
-x option (xtrace):

When this option is set, the shell will print each command and its arguments to the standard error output (stderr) before executing it.
This is useful for debugging scripts, as it allows you to see exactly what commands are being executed.
bash
Copy code
set -x
Your example combines both options:

bash
Copy code
set -xe
This means that the script will exit immediately if any command returns a non-zero exit status (due to the -e option), and it will print each command to stderr before executing it (due to the -x option). This is often used in shell scripts during development or debugging to catch errors early and understand the flow of execution.

close #2 