### PR TITLE
fix: notebook couldn't find conda installatation

### DIFF
--- a/.github/workflows/.docker.yaml
+++ b/.github/workflows/.docker.yaml
@@ -12,7 +12,7 @@ on:
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: in-for-disaster-analytics/tap_llmrepository-docker:sha-2968b7d
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:

--- a/.github/workflows/.docker.yaml
+++ b/.github/workflows/.docker.yaml
@@ -12,7 +12,7 @@ on:
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: in-for-disaster-analytics/tap_llmrepository-docker:sha-2968b7d
+  IMAGE_NAME: in-for-disaster-analytics/tap_llmrepository-docker
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     ssh \
+    wget \
+    unzip \
     vim \
     && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \

--- a/run.sh
+++ b/run.sh
@@ -68,7 +68,7 @@ print(torch.cuda.is_available())
 #export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
 
 
-echo "TACC: running on node $NODE_HOSTNAME_PREFIX on $NODE_HOSTNAME_DOMAIN$WORK/sites-and-stories-nlp-jupyterenv"
+echo "TACC: running on node $NODE_HOSTNAME_PREFIX on $NODE_HOSTNAME_DOMAIN"
 
 TAP_FUNCTIONS="/share/doc/slurm/tap_functions"
 if [ -f ${TAP_FUNCTIONS} ]; then

--- a/run.sh
+++ b/run.sh
@@ -108,6 +108,7 @@ if [ ! -f ${TAP_CERTFILE} ]; then
     exit 1
 fi
 
+#
 # bail if we cannot create a token for the session
 TAP_TOKEN=$(tap_get_token)
 if [ -z "${TAP_TOKEN}" ]; then
@@ -202,7 +203,7 @@ fi
 
 # Webhook callback url for job ready notification.
 # Notification is sent to _INTERACTIVE_WEBHOOK_URL, e.g. https://3dem.org/webhooks/interactive/
-curl -k --data "event_type=WEB&address=${JUPYTER_URL}&owner=${AGAVE_JOB_OWNER}&job_uuid=${AGAVE_JOB_ID}" $INTERACTIVE_WEBHOOK_URL &
+#curl -k --data "event_type=WEB&address=${JUPYTER_URL}&owner=${AGAVE_JOB_OWNER}&job_uuid=${AGAVE_JOB_ID}" $INTERACTIVE_WEBHOOK_URL &
 
 # Delete the session file to kill the job.
 echo $NODE_HOSTNAME_LONG $IPYTHON_PID > $SESSION_FILE

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
 fi
 echo "Installing Conda env"
 python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
-conda env list
+conda env list --json
 conda activate llm
 pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
 echo "\

--- a/run.sh
+++ b/run.sh
@@ -31,7 +31,7 @@ if [ ! -d "$WORK/miniconda3" ]; then
   echo "Miniconda not found in $WORK..."
   echo "Installing..."
   mkdir -p $WORK/miniconda3
-  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $WORK/miniconda3/miniconda.sh
+  curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o $WORK/miniconda3/miniconda.sh
   bash $WORK/miniconda3/miniconda.sh -b -u -p $WORK/miniconda3
   rm -rf $WORK/miniconda3/miniconda.sh
 

--- a/run.sh
+++ b/run.sh
@@ -59,13 +59,13 @@ echo "Installing Conda env"
 #python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
 conda env list --json
 conda activate llm
-#pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
+pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
 echo "\
 import torch
 print(torch.cuda.is_available())
 " | python3
 
-export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
+#export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
 
 
 echo "TACC: running on node $NODE_HOSTNAME_PREFIX on $NODE_HOSTNAME_DOMAIN$WORK/sites-and-stories-nlp-jupyterenv"

--- a/run.sh
+++ b/run.sh
@@ -52,7 +52,7 @@ if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
     CONDA_PKGS_DIRS=$(mktemp -d) conda create -n llm -f $WORK/sites-and-stories-nlp-jupyterenv/.binder/environment.yml
 fi
 echo "Installing Conda env"
-python -m ipykernel install --user --name llm --display-name "Python (llm)"
+python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
 conda activate llm
 pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
 echo "\

--- a/run.sh
+++ b/run.sh
@@ -39,11 +39,15 @@ if [ ! -d "$WORK/miniconda3" ]; then
   conda config --set auto_activate_base false
 fi
 
-echo "Initializing conda..."
-$WORK/miniconda3/bin/conda init bash
+export PATH="$WORK/miniconda3/bin:$PATH"
+conda init bash
 echo "Sourcing .bashrc..."
 source ~/.bashrc
+unset PYTHONPATH
+
+echo "Initializing conda..."
 conda info
+## Path to the python environment where the jupyter notebook packages are installed
 
 if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
     echo "Env not found, downloading"
@@ -52,7 +56,7 @@ if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
     CONDA_PKGS_DIRS=$(mktemp -d) conda create -n llm -f $WORK/sites-and-stories-nlp-jupyterenv/.binder/environment.yml
 fi
 echo "Installing Conda env"
-python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
+#python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
 conda env list --json
 conda activate llm
 pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv

--- a/run.sh
+++ b/run.sh
@@ -65,7 +65,7 @@ import torch
 print(torch.cuda.is_available())
 " | python3
 
-#export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
+export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
 
 
 echo "TACC: running on node $NODE_HOSTNAME_PREFIX on $NODE_HOSTNAME_DOMAIN"

--- a/run.sh
+++ b/run.sh
@@ -53,6 +53,7 @@ if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
 fi
 echo "Installing Conda env"
 python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
+conda env list
 conda activate llm
 pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
 echo "\

--- a/run.sh
+++ b/run.sh
@@ -53,13 +53,13 @@ if [ ! -d "$WORK/sites-and-stories-nlp-jupyterenv" ]; then
     echo "Env not found, downloading"
     wget https://github.com/In-For-Disaster-Analytics/sites-and-stories-nlp/archive/refs/heads/jupyterenv.zip
     unzip *.zip -d $WORK
-    CONDA_PKGS_DIRS=$(mktemp -d) conda create -n llm -f $WORK/sites-and-stories-nlp-jupyterenv/.binder/environment.yml
+    conda env create -n llm -f $WORK/sites-and-stories-nlp-jupyterenv/.binder/environment.yml
 fi
 echo "Installing Conda env"
 #python3 -m ipykernel install --user --name llm --display-name "Python (llm)"
 conda env list --json
 conda activate llm
-pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
+#pip install transformers[torch] ipyfilechooser pypdf ema-workbench huggingface-hub llama-cpp-python llama-index python-dotenv
 echo "\
 import torch
 print(torch.cuda.is_available())
@@ -68,7 +68,7 @@ print(torch.cuda.is_available())
 export TRANSFORMERS_CACHE="$WORK/sites-and-stories-nlp-jupyterenv"
 
 
-echo "TACC: running on node $NODE_HOSTNAME_PREFIX on $NODE_HOSTNAME_DOMAIN"
+echo "TACC: running on node $NODE_HOSTNAME_PREFIX on $NODE_HOSTNAME_DOMAIN$WORK/sites-and-stories-nlp-jupyterenv"
 
 TAP_FUNCTIONS="/share/doc/slurm/tap_functions"
 if [ -f ${TAP_FUNCTIONS} ]; then


### PR DESCRIPTION
1. Rename the docker image: add `tap_`
2. Install required system packages: `wget` and `unzip`
3. This line is updating the PATH variable to include the directory path to the bin directory of a Miniconda installation. This is useful for making the Conda executable and associated tools available for use in the shell without needing to specify the full path each time.
4. Comment webhook callback url